### PR TITLE
fix(core): handle null GNSS, Position and Attitude values

### DIFF
--- a/src/Asv.Drones.Sdr.Core/GnssSource/IGnssSource.cs
+++ b/src/Asv.Drones.Sdr.Core/GnssSource/IGnssSource.cs
@@ -5,7 +5,7 @@ namespace Asv.Drones.Sdr.Core;
 
 public interface IGnssSource
 {
-    IRxValue<GpsRawIntPayload> Gnss { get; }
-    IRxValue<GlobalPositionIntPayload> Position { get;  }
-    IRxValue<AttitudePayload> Attitude { get; }
+    IRxValue<GpsRawIntPayload?> Gnss { get; }
+    IRxValue<GlobalPositionIntPayload?> Position { get;  }
+    IRxValue<AttitudePayload?> Attitude { get; }
 }

--- a/src/Asv.Drones.Sdr.Core/GnssSource/MavlinkGnssSource.cs
+++ b/src/Asv.Drones.Sdr.Core/GnssSource/MavlinkGnssSource.cs
@@ -22,10 +22,10 @@ public class MavlinkGnssSourceConfig
 public class MavlinkGnssSource : DisposableOnceWithCancel, IGnssSource
 {
     private readonly ISdrMavlinkService _svc;
-    private readonly RxValue<GpsRawIntPayload> _gnss;
+    private readonly RxValue<GpsRawIntPayload?> _gnss;
     private readonly MavlinkGnssSourceConfig _config;
-    private readonly RxValue<AttitudePayload> _attitude;
-    private readonly RxValue<GlobalPositionIntPayload> _position;
+    private readonly RxValue<AttitudePayload?> _attitude;
+    private readonly RxValue<GlobalPositionIntPayload?> _position;
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
     private readonly LinkIndicator _link = new(3);
     private bool _needToRequestAgain;
@@ -39,11 +39,11 @@ public class MavlinkGnssSource : DisposableOnceWithCancel, IGnssSource
         
         _config = config.Get<MavlinkGnssSourceConfig>();
         var pkts = svc.Router.FilterVehicle(_config.GnssSystemId, _config.GnssComponentId).Publish().RefCount();
-        _position = new RxValue<GlobalPositionIntPayload>().DisposeItWith(Disposable);
+        _position = new RxValue<GlobalPositionIntPayload?>().DisposeItWith(Disposable);
         pkts.Filter<GlobalPositionIntPacket>().Select(_=>_.Payload).Subscribe(_position).DisposeItWith(Disposable);
-        _gnss = new RxValue<GpsRawIntPayload>().DisposeItWith(Disposable);
+        _gnss = new RxValue<GpsRawIntPayload?>().DisposeItWith(Disposable);
         pkts.Filter<GpsRawIntPacket>().Select(_=>_.Payload).Subscribe(_gnss).DisposeItWith(Disposable);
-        _attitude = new RxValue<AttitudePayload>().DisposeItWith(Disposable);
+        _attitude = new RxValue<AttitudePayload?>().DisposeItWith(Disposable);
         pkts.Filter<AttitudePacket>().Select(_=>_.Payload).Subscribe(_attitude).DisposeItWith(Disposable);
         pkts.Filter<HeartbeatPacket>().Where(_=>_.Payload.Autopilot == MavAutopilot.MavAutopilotArdupilotmega).Subscribe(_=>
         {
@@ -93,10 +93,10 @@ public class MavlinkGnssSource : DisposableOnceWithCancel, IGnssSource
         }
     }
 
-    public IRxValue<GpsRawIntPayload> Gnss => _gnss;
+    public IRxValue<GpsRawIntPayload?> Gnss => _gnss;
 
-    public IRxValue<GlobalPositionIntPayload> Position => _position;
+    public IRxValue<GlobalPositionIntPayload?> Position => _position;
 
-    public IRxValue<AttitudePayload> Attitude => _attitude;
+    public IRxValue<AttitudePayload?> Attitude => _attitude;
 }
 

--- a/src/Asv.Drones.Sdr.Core/ModeSwitcher/Mode/GpWorkMode.cs
+++ b/src/Asv.Drones.Sdr.Core/ModeSwitcher/Mode/GpWorkMode.cs
@@ -17,38 +17,78 @@ public class GpWorkMode : WorkModeBase<IAnalyzerGp, AsvSdrRecordDataGpPayload>
     {
     }
     protected override void InternalFill(AsvSdrRecordDataGpPayload payload, Guid record, uint dataIndex,
-        GpsRawIntPayload gnss, AttitudePayload attitude,
-        GlobalPositionIntPayload position)
+        GpsRawIntPayload? gnss, AttitudePayload? attitude,
+        GlobalPositionIntPayload? position)
     {
         payload.DataIndex = dataIndex;
         record.TryWriteBytes(payload.RecordGuid);
         // GNSS
-        payload.GnssFixType = gnss.FixType;
-        payload.GnssLat = gnss.Lat;
-        payload.GnssLon = gnss.Lon;
-        payload.GnssAlt = gnss.Alt;
-        payload.GnssEph = gnss.Eph;
-        payload.GnssEpv = gnss.Epv;
-        payload.GnssVel = gnss.Vel;
-        payload.GnssVel = gnss.Vel;
-        payload.GnssSatellitesVisible = gnss.SatellitesVisible;
-        payload.GnssAltEllipsoid = gnss.AltEllipsoid;
-        payload.GnssHAcc = gnss.HAcc;
-        payload.GnssVAcc = gnss.VAcc;
-        payload.GnssVelAcc = gnss.VelAcc;
+        if (gnss != null)
+        {
+            payload.GnssFixType = gnss.FixType;
+            payload.GnssLat = gnss.Lat;
+            payload.GnssLon = gnss.Lon;
+            payload.GnssAlt = gnss.Alt;
+            payload.GnssEph = gnss.Eph;
+            payload.GnssEpv = gnss.Epv;
+            payload.GnssVel = gnss.Vel;
+            payload.GnssSatellitesVisible = gnss.SatellitesVisible;
+            payload.GnssAltEllipsoid = gnss.AltEllipsoid;
+            payload.GnssHAcc = gnss.HAcc;
+            payload.GnssVAcc = gnss.VAcc;
+            payload.GnssVelAcc = gnss.VelAcc;
+        }
+        else
+        {
+            payload.GnssFixType = GpsFixType.GpsFixTypeNoGps;
+            payload.GnssLat = 0;
+            payload.GnssLon = 0;
+            payload.GnssAlt = 0;
+            payload.GnssEph = 0;
+            payload.GnssEpv = 0;
+            payload.GnssVel = 0;
+            payload.GnssSatellitesVisible = 0;
+            payload.GnssAltEllipsoid = 0;
+            payload.GnssHAcc = 0;
+            payload.GnssVAcc = 0;
+            payload.GnssVelAcc = 0;
+        }
         // Global position
-        payload.Lat = position.Lat;
-        payload.Lon = position.Lon;
-        payload.Alt = position.Alt;
-        payload.RelativeAlt = position.RelativeAlt;
-        payload.Vx = position.Vx;
-        payload.Vy = position.Vy;
-        payload.Vz = position.Vz;
-        payload.Hdg = position.Hdg;
+        if (position != null)
+        {
+            payload.Lat = position.Lat;
+            payload.Lon = position.Lon;
+            payload.Alt = position.Alt;
+            payload.RelativeAlt = position.RelativeAlt;
+            payload.Vx = position.Vx;
+            payload.Vy = position.Vy;
+            payload.Vz = position.Vz;
+            payload.Hdg = position.Hdg;
+        }
+        else
+        {
+            payload.Lat = 0;
+            payload.Lon = 0;
+            payload.Alt = 0;
+            payload.RelativeAlt = 0;
+            payload.Vx = 0;
+            payload.Vy = 0;
+            payload.Vz = 0;
+            payload.Hdg = 0;
+        }
         // Attitude
-        payload.Roll = attitude.Roll;
-        payload.Pitch = attitude.Pitch;
-        payload.Yaw = attitude.Yaw;
+        if (attitude != null)
+        {
+            payload.Roll = attitude.Roll;
+            payload.Pitch = attitude.Pitch;
+            payload.Yaw = attitude.Yaw;
+        }
+        else
+        {
+            payload.Roll = 0;
+            payload.Pitch = 0;
+            payload.Yaw = 0;
+        }
         // Measure
         Analyzer.Fill(payload);
     }

--- a/src/Asv.Drones.Sdr.Core/ModeSwitcher/Mode/LlzWorkMode.cs
+++ b/src/Asv.Drones.Sdr.Core/ModeSwitcher/Mode/LlzWorkMode.cs
@@ -17,38 +17,78 @@ public class LlzWorkMode : WorkModeBase<IAnalyzerLlz, AsvSdrRecordDataLlzPayload
     {
     }
     protected override void InternalFill(AsvSdrRecordDataLlzPayload payload, Guid record, uint dataIndex,
-        GpsRawIntPayload gnss, AttitudePayload attitude,
-        GlobalPositionIntPayload position)
+        GpsRawIntPayload? gnss, AttitudePayload? attitude,
+        GlobalPositionIntPayload? position)
     {
         payload.DataIndex = dataIndex;
         record.TryWriteBytes(payload.RecordGuid);
         // GNSS
-        payload.GnssFixType = gnss.FixType;
-        payload.GnssLat = gnss.Lat;
-        payload.GnssLon = gnss.Lon;
-        payload.GnssAlt = gnss.Alt;
-        payload.GnssEph = gnss.Eph;
-        payload.GnssEpv = gnss.Epv;
-        payload.GnssVel = gnss.Vel;
-        payload.GnssVel = gnss.Vel;
-        payload.GnssSatellitesVisible = gnss.SatellitesVisible;
-        payload.GnssAltEllipsoid = gnss.AltEllipsoid;
-        payload.GnssHAcc = gnss.HAcc;
-        payload.GnssVAcc = gnss.VAcc;
-        payload.GnssVelAcc = gnss.VelAcc;
+        if (gnss != null)
+        {
+            payload.GnssFixType = gnss.FixType;
+            payload.GnssLat = gnss.Lat;
+            payload.GnssLon = gnss.Lon;
+            payload.GnssAlt = gnss.Alt;
+            payload.GnssEph = gnss.Eph;
+            payload.GnssEpv = gnss.Epv;
+            payload.GnssVel = gnss.Vel;
+            payload.GnssSatellitesVisible = gnss.SatellitesVisible;
+            payload.GnssAltEllipsoid = gnss.AltEllipsoid;
+            payload.GnssHAcc = gnss.HAcc;
+            payload.GnssVAcc = gnss.VAcc;
+            payload.GnssVelAcc = gnss.VelAcc;
+        }
+        else
+        {
+            payload.GnssFixType = GpsFixType.GpsFixTypeNoGps;
+            payload.GnssLat = 0;
+            payload.GnssLon = 0;
+            payload.GnssAlt = 0;
+            payload.GnssEph = 0;
+            payload.GnssEpv = 0;
+            payload.GnssVel = 0;
+            payload.GnssSatellitesVisible = 0;
+            payload.GnssAltEllipsoid = 0;
+            payload.GnssHAcc = 0;
+            payload.GnssVAcc = 0;
+            payload.GnssVelAcc = 0;
+        }
         // Global position
-        payload.Lat = position.Lat;
-        payload.Lon = position.Lon;
-        payload.Alt = position.Alt;
-        payload.RelativeAlt = position.RelativeAlt;
-        payload.Vx = position.Vx;
-        payload.Vy = position.Vy;
-        payload.Vz = position.Vz;
-        payload.Hdg = position.Hdg;
+        if (position != null)
+        {
+            payload.Lat = position.Lat;
+            payload.Lon = position.Lon;
+            payload.Alt = position.Alt;
+            payload.RelativeAlt = position.RelativeAlt;
+            payload.Vx = position.Vx;
+            payload.Vy = position.Vy;
+            payload.Vz = position.Vz;
+            payload.Hdg = position.Hdg;
+        }
+        else
+        {
+            payload.Lat = 0;
+            payload.Lon = 0;
+            payload.Alt = 0;
+            payload.RelativeAlt = 0;
+            payload.Vx = 0;
+            payload.Vy = 0;
+            payload.Vz = 0;
+            payload.Hdg = 0;
+        }
         // Attitude
-        payload.Roll = attitude.Roll;
-        payload.Pitch = attitude.Pitch;
-        payload.Yaw = attitude.Yaw;
+        if (attitude != null)
+        {
+            payload.Roll = attitude.Roll;
+            payload.Pitch = attitude.Pitch;
+            payload.Yaw = attitude.Yaw;
+        }
+        else
+        {
+            payload.Roll = 0;
+            payload.Pitch = 0;
+            payload.Yaw = 0;
+        }
         // Measure
         Analyzer.Fill(payload);
     }

--- a/src/Asv.Drones.Sdr.Core/ModeSwitcher/Mode/VorWorkMode.cs
+++ b/src/Asv.Drones.Sdr.Core/ModeSwitcher/Mode/VorWorkMode.cs
@@ -17,38 +17,78 @@ public class VorWorkMode : WorkModeBase<IAnalyzerVor, AsvSdrRecordDataVorPayload
     {
     }
     protected override void InternalFill(AsvSdrRecordDataVorPayload payload, Guid record, uint dataIndex,
-        GpsRawIntPayload gnss, AttitudePayload attitude,
-        GlobalPositionIntPayload position)
+        GpsRawIntPayload? gnss, AttitudePayload? attitude,
+        GlobalPositionIntPayload? position)
     {
         payload.DataIndex = dataIndex;
         record.TryWriteBytes(payload.RecordGuid);
         // GNSS
-        payload.GnssFixType = gnss.FixType;
-        payload.GnssLat = gnss.Lat;
-        payload.GnssLon = gnss.Lon;
-        payload.GnssAlt = gnss.Alt;
-        payload.GnssEph = gnss.Eph;
-        payload.GnssEpv = gnss.Epv;
-        payload.GnssVel = gnss.Vel;
-        payload.GnssVel = gnss.Vel;
-        payload.GnssSatellitesVisible = gnss.SatellitesVisible;
-        payload.GnssAltEllipsoid = gnss.AltEllipsoid;
-        payload.GnssHAcc = gnss.HAcc;
-        payload.GnssVAcc = gnss.VAcc;
-        payload.GnssVelAcc = gnss.VelAcc;
+        if (gnss != null)
+        {
+            payload.GnssFixType = gnss.FixType;
+            payload.GnssLat = gnss.Lat;
+            payload.GnssLon = gnss.Lon;
+            payload.GnssAlt = gnss.Alt;
+            payload.GnssEph = gnss.Eph;
+            payload.GnssEpv = gnss.Epv;
+            payload.GnssVel = gnss.Vel;
+            payload.GnssSatellitesVisible = gnss.SatellitesVisible;
+            payload.GnssAltEllipsoid = gnss.AltEllipsoid;
+            payload.GnssHAcc = gnss.HAcc;
+            payload.GnssVAcc = gnss.VAcc;
+            payload.GnssVelAcc = gnss.VelAcc;
+        }
+        else
+        {
+            payload.GnssFixType = GpsFixType.GpsFixTypeNoGps;
+            payload.GnssLat = 0;
+            payload.GnssLon = 0;
+            payload.GnssAlt = 0;
+            payload.GnssEph = 0;
+            payload.GnssEpv = 0;
+            payload.GnssVel = 0;
+            payload.GnssSatellitesVisible = 0;
+            payload.GnssAltEllipsoid = 0;
+            payload.GnssHAcc = 0;
+            payload.GnssVAcc = 0;
+            payload.GnssVelAcc = 0;
+        }
         // Global position
-        payload.Lat = position.Lat;
-        payload.Lon = position.Lon;
-        payload.Alt = position.Alt;
-        payload.RelativeAlt = position.RelativeAlt;
-        payload.Vx = position.Vx;
-        payload.Vy = position.Vy;
-        payload.Vz = position.Vz;
-        payload.Hdg = position.Hdg;
+        if (position != null)
+        {
+            payload.Lat = position.Lat;
+            payload.Lon = position.Lon;
+            payload.Alt = position.Alt;
+            payload.RelativeAlt = position.RelativeAlt;
+            payload.Vx = position.Vx;
+            payload.Vy = position.Vy;
+            payload.Vz = position.Vz;
+            payload.Hdg = position.Hdg;
+        }
+        else
+        {
+            payload.Lat = 0;
+            payload.Lon = 0;
+            payload.Alt = 0;
+            payload.RelativeAlt = 0;
+            payload.Vx = 0;
+            payload.Vy = 0;
+            payload.Vz = 0;
+            payload.Hdg = 0;
+        }
         // Attitude
-        payload.Roll = attitude.Roll;
-        payload.Pitch = attitude.Pitch;
-        payload.Yaw = attitude.Yaw;
+        if (attitude != null)
+        {
+            payload.Roll = attitude.Roll;
+            payload.Pitch = attitude.Pitch;
+            payload.Yaw = attitude.Yaw;
+        }
+        else
+        {
+            payload.Roll = 0;
+            payload.Pitch = 0;
+            payload.Yaw = 0;
+        }
         // Measure
         Analyzer.Fill(payload);
     }   

--- a/src/Asv.Drones.Sdr.Core/ModeSwitcher/WorkModeBase.cs
+++ b/src/Asv.Drones.Sdr.Core/ModeSwitcher/WorkModeBase.cs
@@ -60,6 +60,6 @@ public abstract class WorkModeBase<TAnalyzer,TPayload>: DisposableOnceWithCancel
     }
 
     protected abstract void InternalFill(TPayload payload, Guid record, uint dataIndex,
-        GpsRawIntPayload gnss, AttitudePayload attitude, GlobalPositionIntPayload position);
+        GpsRawIntPayload? gnss, AttitudePayload? attitude, GlobalPositionIntPayload? position);
 }
 


### PR DESCRIPTION
Modified method signatures and implementations in various classes to handle cases where GNSS, Position, and Attitude values could be null. Previously, these values were not nullable, which caused issues when a null was encountered, as it could not be handled appropriately. Changes include adding null checks before assignment in VorWorkMode.cs, GpWorkMode.cs, LlzWorkMode.cs and WorkModeBase.cs, and modifying variable declarations and method return types in MavlinkGnssSource.cs and IGnssSource.cs to allow null values. These changes aim to improve code robustness and prevent null reference exceptions during runtime.

Asana: https://app.asana.com/0/1203851531040615/1205072730584948/f