### PR TITLE
fix(core): add FrequencyHz to payload in Vor and Llz modes

### DIFF
--- a/src/Asv.Drones.Sdr.Core/ModeSwitcher/Mode/LlzWorkMode.cs
+++ b/src/Asv.Drones.Sdr.Core/ModeSwitcher/Mode/LlzWorkMode.cs
@@ -21,6 +21,7 @@ public class LlzWorkMode : WorkModeBase<IAnalyzerLlz, AsvSdrRecordDataLlzPayload
         GlobalPositionIntPayload? position)
     {
         payload.DataIndex = dataIndex;
+        payload.TotalFreq = FrequencyHz;
         record.TryWriteBytes(payload.RecordGuid);
         // GNSS
         if (gnss != null)

--- a/src/Asv.Drones.Sdr.Core/ModeSwitcher/Mode/VorWorkMode.cs
+++ b/src/Asv.Drones.Sdr.Core/ModeSwitcher/Mode/VorWorkMode.cs
@@ -21,6 +21,7 @@ public class VorWorkMode : WorkModeBase<IAnalyzerVor, AsvSdrRecordDataVorPayload
         GlobalPositionIntPayload? position)
     {
         payload.DataIndex = dataIndex;
+        payload.TotalFreq = FrequencyHz;
         record.TryWriteBytes(payload.RecordGuid);
         // GNSS
         if (gnss != null)


### PR DESCRIPTION
Included the FrequencyHz to payload in both VorWorkMode and LlzWorkMode to provide comprehensive data. Previously, this aspect was being overlooked and didn't make it into payload thus compromising the data completeness in record.

Asana: https://app.asana.com/0/1203851531040615/1205361528081939/f