### PR TITLE
feat: add OSD telemetry rate and display updates

### DIFF
--- a/src/Asv.Drones.Sdr.Core/Mavlink/DefaultParams.cs
+++ b/src/Asv.Drones.Sdr.Core/Mavlink/DefaultParams.cs
@@ -23,4 +23,19 @@ public static class MavlinkDefaultParams
         DefaultValue = 0,
         Increment = 1,
     };
+    
+    [Export(typeof(IMavParamTypeMetadata))]
+    public static IMavParamTypeMetadata OsdTelemetryRate = new MavParamTypeMetadata("OSD_TEL_RATE", MavParamType.MavParamTypeInt32)
+    {
+        Group = Group,
+        Category = Category,
+        ShortDesc = "OSD telemetry rate",
+        LongDesc = "The frequency at which the display is updated to display telemetry in OSD.",
+        Units = "Seconds",
+        RebootRequired = false,
+        MinValue = 0,
+        MaxValue = Int32.MaxValue,
+        DefaultValue = 0,
+        Increment = 1,
+    };
 }

--- a/src/Asv.Drones.Sdr.Core/ModeSwitcher/Mode/GpWorkMode.cs
+++ b/src/Asv.Drones.Sdr.Core/ModeSwitcher/Mode/GpWorkMode.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
+using System.Reactive.Linq;
 using Asv.Cfg;
 using Asv.Common;
+using Asv.Drones.Sdr.Core.Mavlink;
 using Asv.Mavlink;
 using Asv.Mavlink.V2.AsvSdr;
 using Asv.Mavlink.V2.Common;
@@ -12,11 +14,46 @@ namespace Asv.Drones.Sdr.Core;
 [PartCreationPolicy(CreationPolicy.NonShared)]
 public class GpWorkMode : WorkModeBase<IAnalyzerGp, AsvSdrRecordDataGpPayload>
 {
+    private float _totalAm90;
+    private float _totalAm150;
+
+    private IDisposable _osdTelemTimerDisposable;
+    private readonly ISdrMavlinkService _svc;
+
     [ImportingConstructor]
-    public GpWorkMode(IGnssSource gnssSource,ITimeService time, IConfiguration configuration, CompositionContainer container) 
+    public GpWorkMode(ISdrMavlinkService svc, IGnssSource gnssSource,ITimeService time, IConfiguration configuration, CompositionContainer container) 
         : base(AsvSdrCustomMode.AsvSdrCustomModeGp , gnssSource,time, configuration, container)
     {
+        _svc = svc;
+        
+        UpdateOsdTelemetryTimer(_svc.Server.Params[MavlinkDefaultParams.OsdTelemetryRate]);
+        
+        _svc.Server.Params.OnUpdated.Subscribe(_ =>
+        {
+            if (_.Metadata.Name == MavlinkDefaultParams.OsdTelemetryRate.Name)
+            {
+                UpdateOsdTelemetryTimer(_.NewValue);
+            }
+        }).DisposeItWith(Disposable);
+        
+        Disposable.AddAction(() => _osdTelemTimerDisposable?.Dispose());
     }
+    
+    private void UpdateOsdTelemetryTimer(int rate)
+    {
+        _osdTelemTimerDisposable?.Dispose();
+
+        if (rate > 0)
+        {
+            _osdTelemTimerDisposable = Observable.Timer(TimeSpan.Zero, TimeSpan.FromSeconds(rate))
+                .Subscribe(_ =>
+                {
+                    _svc.Server.StatusText.Info($"Total DDM: {_totalAm90 - _totalAm150}");
+                    _svc.Server.StatusText.Info($"Total SDM: {_totalAm90 + _totalAm150}");
+                });
+        }
+    }
+    
     protected override void InternalFill(AsvSdrRecordDataGpPayload payload, Guid record, uint dataIndex,
         GpsRawIntPayload? gnss, AttitudePayload? attitude,
         GlobalPositionIntPayload? position)
@@ -93,5 +130,8 @@ public class GpWorkMode : WorkModeBase<IAnalyzerGp, AsvSdrRecordDataGpPayload>
         }
         // Measure
         Analyzer.Fill(payload);
+        
+        _totalAm90 = payload.TotalAm90;
+        _totalAm150 = payload.TotalAm150;
     }
 }


### PR DESCRIPTION
Implemented an On-Screen Display (OSD) telemetry rate parameter and updated the way telemetry data is presented in the OSD for 'GPWorkMode', 'LlzWorkMode', and 'VorWorkMode' of the project 'Asv.Drones.Sdr'. The telemetry rate is now adjustable and the display information includes the total DDM, SDM, and Azimuth depending on the mode. The changes allow users to customize the frequency of telemetry data updates and improve the visibility of important values.

Asana: https://app.asana.com/0/1203851531040615/1206083632668454/f