### PR TITLE
feat: update AsvMavlinkVersion and add mission items collection

### DIFF
--- a/src/Asv.Drones.Sdr.Custom.props
+++ b/src/Asv.Drones.Sdr.Custom.props
@@ -5,7 +5,7 @@
     <ProductVersion>0.1.1</ProductVersion>
     <AvaloniaVersion>11.0.0</AvaloniaVersion>
     <AsvCommonVersion>1.13.1</AsvCommonVersion>
-    <AsvMavlinkVersion>3.6.0-alpha08</AsvMavlinkVersion>
+    <AsvMavlinkVersion>3.6.0-alpha12</AsvMavlinkVersion>
     <CompositionVersion>7.0.0</CompositionVersion>
     <NLogVersion>5.2.6</NLogVersion>
   </PropertyGroup>


### PR DESCRIPTION
Updated the AsvMavlinkVersion from 3.6.0-alpha08 to 3.6.0-alpha12 in Asv.Drones.Sdr.Custom.props file. This version update brings important fixes and improvements to the module. Also, added a ReadOnlyObservableCollection for mission items in SdrMavlinkService of Asv.Drones.Sdr.Core. This will enable us to store and manage the server's mission items. When any changes are made to the list of mission items, they are now automatically saved to the configuration. This update enhances the functionality of our mission planning tool and allows for a more dynamic interaction with the mission items.

Asana: https://app.asana.com/0/0/1206187948272232/f